### PR TITLE
create output directory if it doesnt exist

### DIFF
--- a/protocol/device_classes.py
+++ b/protocol/device_classes.py
@@ -1,3 +1,4 @@
+import os
 import time
 from message_classes import Message, Action
 from abstract_network import AbstractTransceiver
@@ -112,6 +113,7 @@ class ThisDevice(Device):
         self.received: int | None = None  # will be an int representation of message
         self.transceiver: AbstractTransceiver = transceiver  # plugin object for sending and receiving messages
         self.numHeardDLIST: int = 0
+        os.makedirs(OUTPUT_DIR, exist_ok=True)
         self.outPath = OUTPUT_DIR / ("device_log_" + str(self.id) + ".csv")
         self.active = True
 


### PR DESCRIPTION
When starting the simulation, I got a FileNotFound error because the output log directory did not exist initially. This small change basically just creates an output directory if it doesn't exist, and doesn't a raise an error if it does. 